### PR TITLE
Fix bug when number of GFFs is large

### DIFF
--- a/scripts/run_PIRATE.pl
+++ b/scripts/run_PIRATE.pl
@@ -212,6 +212,7 @@ my $panargs = join(" ", @pargs);
 my $genome2loci = "$pirate_dir/genome2loci.tab";
 my $it_dir = "$pirate_dir/pangenome_iterations";
 my $gff_dir = "$pirate_dir/modified_gffs";
+my @input_gffs = (<$input_dir/*.gff>);
 
 # only perform pre-processing if constructing original pangenome.
 if ( $pan_off == 0 ){
@@ -228,7 +229,10 @@ if ( $pan_off == 0 ){
 	# clear existing gffs
 	unlink glob "$gff_dir/*.gff";
 	`echo -n "" > $pirate_dir/gff_parser_log.txt`;
-	`ls $input_dir/*.gff | parallel -j $threads \"perl $script_path/parse_GFF.pl {} $gff_dir >> $pirate_dir/gff_parser_log.txt 2>> $pirate_dir/gff_parser_log.txt\"`;
+
+	while ( my @chunk = splice @input_gffs, 0, $threads ) {
+		`parallel -j $threads \"perl $script_path/parse_GFF.pl {} $gff_dir >> $pirate_dir/gff_parser_log.txt 2>> $pirate_dir/gff_parser_log.txt\" ::: @chunk`;
+	}
 
 	# check number of successfully standardised gff files
 	opendir(DIR, $gff_dir);


### PR DESCRIPTION
When the number of GFFs is large (in my case, >30000), PIRATE fails when "Standardising and checking input files". This happens because the number of files can exceed the maximum argument number for the external shell commands PIRATE uses at this step. This patch avoids this issue by loading the GFF file paths into a perl array, which then sends chunks equal in size to `$threads` to `parallel` instead of getting the file list with `ls`.